### PR TITLE
chore: add DeepSource static analysis configuration

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,16 @@
+version = 1
+
+test_patterns = [
+  "**/*_test.go"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_root = "github.com/munditrade/provider-sql-crossplane"
+
+[[analyzers]]
+name = "secrets"
+enabled = true


### PR DESCRIPTION
Adds `.deepsource.toml` to enable DeepSource automated code analysis.

This enables:
- **Secrets detection** on all repos
- **Language-specific analyzers** matched to the repo's primary language

DeepSource runs on every PR and reports issues inline. No CI changes needed — the DeepSource GitHub App is already installed.